### PR TITLE
ci: Automate LZ4 release check and build runtime updates

### DIFF
--- a/.github/workflows/build-native-lz4.yaml
+++ b/.github/workflows/build-native-lz4.yaml
@@ -11,6 +11,8 @@ name: Build-Native-LZ4
 #     - Commit that lz4 dynamic lib artifacts placed in src/NativeCompressions.LZ4.Runtime/runtimes/{platform_name}/native/{lib}
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *' # Every day at 3:00 AM (UTC)
 
 jobs:
   check_new_release:

--- a/.github/workflows/build-native-lz4.yaml
+++ b/.github/workflows/build-native-lz4.yaml
@@ -1,18 +1,18 @@
-# Follow LZ4 latest release by cron update
 name: Build-Native-LZ4
 
+# Follow LZ4 latest release by cron update
+# 1.  Check for LZ4 updates - compare submodule commit ID with latest release commit
+# 2.  If no changes, checkout in each build job, build and upload artifacts.
+# 2". If changes exist, update submodule after checkout in each build job, build and upload artifacts
+# 3.  Upload packages to GitHub Actions summary
+# 4.  If changes exist, Create a branch and PR. Separate PRs for each LZ4 release are preferred (avoid updating in a single PR)
+#     PR includes following changes.
+#     - Commit that updates the submodule
+#     - Commit that lz4 dynamic lib artifacts placed in src/NativeCompressions.LZ4.Runtime/runtimes/{platform_name}/native/{lib}
 on:
   workflow_dispatch:
 
 jobs:
-  # LZ4の更新をチェック - submoduleのcommit id を見て、最新リリースのコミットと比較
-  # 変化なければシカト
-  # 変化あれば、各ビルドジョブにてcheckout後にsubmoduleを更新、ビルドして成果物をアップロード
-  # ブランチを切って、PRを作成する。LZ4のリリースごとに別のPRが望ましい。(1つのPRにして更新するのは避ける)
-  # PRは以下を含む
-  #   - サブモジュールを更新したコミット
-  #   - ビルドした成果物をsrc/NativeCompressions.LZ4.Runtime/runtimesに配置
-
   check_new_release:
     permissions:
       contents: read
@@ -62,6 +62,7 @@ jobs:
           fi
 
   build-windows:
+    needs: [check_new_release]
     strategy:
       matrix:
         arch: [x64]
@@ -78,6 +79,14 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 1
+      - name: Update submodule to latest release
+        if: ${{ needs.check_new_release.outputs.needs_update == 'true' }}
+        run: |
+          cd lz4
+            git fetch --tags
+            git checkout ${{ needs.check_new_release.outputs.latest_tag }}
+          cd ..
+          echo "Updated lz4 submodule to ${{ needs.check_new_release.outputs.latest_tag }}"
       - name: Setup MSYS2
         uses: msys2/setup-msys2@fb197b72ce45fb24f17bf3f807a388985654d1f2 # v2.29.0
         with:
@@ -106,6 +115,7 @@ jobs:
           path: artifacts/win-${{ matrix.arch }}/*
 
   build-windows-arm64:
+    needs: [check_new_release]
     permissions:
       contents: read
     runs-on: ubuntu-24.04
@@ -114,9 +124,17 @@ jobs:
       - uses: Cysharp/Actions/.github/actions/checkout@main
         with:
           submodules: recursive
+      - name: Update submodule to latest release
+        if: ${{ needs.check_new_release.outputs.needs_update == 'true' }}
+        run: |
+          cd lz4
+            git fetch --tags
+            git checkout ${{ needs.check_new_release.outputs.latest_tag }}
+          cd ..
+          echo "Updated lz4 submodule to ${{ needs.check_new_release.outputs.latest_tag }}"
       - name: Build using Docker
         run: |
-          docker run --rm -v $PWD:/work \
+          docker run --rm -v "$PWD:/work" \
             mstorsjo/llvm-mingw:latest \
             bash -c "cd /work/lz4/lib && \
               aarch64-w64-mingw32-gcc -O3 -shared \
@@ -135,6 +153,7 @@ jobs:
           path: artifacts/win-arm64/*
 
   build-linux:
+    needs: [check_new_release]
     permissions:
       contents: read
     runs-on: ubuntu-24.04
@@ -153,6 +172,14 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 1
+      - name: Update submodule to latest release
+        if: ${{ needs.check_new_release.outputs.needs_update == 'true' }}
+        run: |
+          cd lz4
+            git fetch --tags
+            git checkout ${{ needs.check_new_release.outputs.latest_tag }}
+          cd ..
+          echo "Updated lz4 submodule to ${{ needs.check_new_release.outputs.latest_tag }}"
       - name: Install ARM64 cross-compiler
         if: matrix.arch == 'arm64'
         run: |
@@ -162,9 +189,9 @@ jobs:
         run: |
           cd lz4/lib
           make BUILD_STATIC=no BUILD_SHARED=yes \
-              CC="${{ matrix.cc }}" \
-              SRCFILES="lz4.c lz4hc.c lz4frame.c xxhash.c"
-          ls -la *.so*
+            CC="${{ matrix.cc }}" \
+            SRCFILES="lz4.c lz4hc.c lz4frame.c xxhash.c"
+          ls -la ./*.so*
           file liblz4.so*
       - name: Prepare artifacts
         run: |
@@ -182,6 +209,7 @@ jobs:
           path: artifacts/linux-${{ matrix.arch }}/*
 
   build-macos:
+    needs: [check_new_release]
     permissions:
       contents: read
     strategy:
@@ -198,6 +226,14 @@ jobs:
       - uses: Cysharp/Actions/.github/actions/checkout@main
         with:
           submodules: recursive
+      - name: Update submodule to latest release
+        if: ${{ needs.check_new_release.outputs.needs_update == 'true' }}
+        run: |
+          cd lz4
+            git fetch --tags
+            git checkout ${{ needs.check_new_release.outputs.latest_tag }}
+          cd ..
+          echo "Updated lz4 submodule to ${{ needs.check_new_release.outputs.latest_tag }}"
       - name: Build dynamic library
         run: |
           cd lz4/lib
@@ -205,7 +241,7 @@ jobs:
               CFLAGS="${{ matrix.flags }} -O3" \
               SRCFILES="lz4.c lz4hc.c lz4frame.c xxhash.c"
 
-          lipo -info *.dylib
+          lipo -info ./*.dylib
       - name: Prepare artifacts
         run: |
           mkdir -p artifacts/osx-${{ matrix.arch }}
@@ -271,3 +307,99 @@ jobs:
           path: |
             lz4-native-libraries.tar.gz
             lz4-native-libraries.zip
+
+  create-pr:
+    needs: [check_new_release, package-all]
+    if: ${{ needs.check_new_release.outputs.needs_update == 'true' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      NEW_BRANCH_NAME: "automate/lz4-${{ needs.check_new_release.outputs.latest_tag }}"
+      LATEST_TAG: ${{ needs.check_new_release.outputs.latest_tag }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: Cysharp/Actions/.github/actions/checkout@main
+        with:
+          submodules: recursive
+      - name: Configure Git
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+      - name: Create new branch
+        run: git checkout -b "${NEW_BRANCH_NAME}"
+      # update submodule
+      - name: Update submodule to latest release
+        if: ${{ needs.check_new_release.outputs.needs_update == 'true' }}
+        run: |
+          echo "Updated lz4 submodule to ${LATEST_TAG}"
+          cd lz4
+            git fetch --tags
+            git checkout "${LATEST_TAG}"
+          cd ..
+          git add lz4
+          git commit -m "automate: Update LZ4 submodule to ${LATEST_TAG}"
+      # update runtimes
+      - name: Download all artifacts
+        uses: Cysharp/Actions/.github/actions/download-artifact@main
+        with:
+          path: artifacts
+      - name: Place new runtimes
+        env:
+          DEST_BASE_PATH: src/NativeCompressions.LZ4.Runtime/runtimes
+        run: |
+          echo "Updated lz4 runtimes to ${LATEST_TAG}"
+
+          mkdir -p "${DEST_BASE_PATH}/{linux-x64,linux-arm64}/native"
+          mkdir -p "${DEST_BASE_PATH}/{osx-arm64,osx-x64}/native"
+          mkdir -p "${DEST_BASE_PATH}/{win-arm64,win-x64}/native"
+
+          # Windows
+          if [ -f artifacts/lz4-win-x64/lz4.dll ]; then
+            cp -f artifacts/lz4-win-x64/lz4.dll "${DEST_BASE_PATH}/win-x64/native/lz4.dll"
+          fi
+          if [ -f artifacts/lz4-win-arm64/lz4.dll ]; then
+            cp -f artifacts/lz4-win-arm64/lz4.dll "${DEST_BASE_PATH}/win-arm64/native/lz4.dll"
+          fi
+
+          # Linux
+          if [ -f artifacts/lz4-linux-x64/liblz4.so ]; then
+            cp -f artifacts/lz4-linux-x64/liblz4.so "${DEST_BASE_PATH}/linux-x64/native/liblz4.so"
+          fi
+          if [ -f artifacts/lz4-linux-arm64/liblz4.so ]; then
+            cp -f artifacts/lz4-linux-arm64/liblz4.so "${DEST_BASE_PATH}/linux-arm64/native/liblz4.so"
+          fi
+
+          # macOS
+          if [ -f artifacts/lz4-osx-x64/liblz4.dylib ]; then
+            cp -f artifacts/lz4-osx-x64/liblz4.dylib "${DEST_BASE_PATH}/osx-x64/native/liblz4.dylib"
+          fi
+          if [ -f artifacts/lz4-osx-arm64/liblz4.dylib ]; then
+            cp -f artifacts/lz4-osx-arm64/liblz4.dylib "${DEST_BASE_PATH}/osx-arm64/native/liblz4.dylib"
+          fi
+
+          # Commit runtime updates
+          git add "${DEST_BASE_PATH}"
+          git commit -m "automate: Update LZ4 native libraries to ${LATEST_TAG}"
+      # create PR
+      - name: Push branch and create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Push the branch
+          git push origin "${NEW_BRANCH_NAME}"
+
+          cat <<'EOF' > artifacts/pr_body.txt
+          This PR updates LZ4 to the latest release `${{ needs.check_new_release.outputs.latest_tag }}` ([${{ needs.check_new_release.outputs.latest_commit }}](https://github.com/lz4/lz4/commit/${{ needs.check_new_release.outputs.latest_commit }}))
+
+          ## Changes
+          - Updated LZ4 submodule to ${LATEST_TAG}
+          - Updated native libraries for all platforms (Windows x64/ARM64, Linux x64/ARM64, macOS x64/ARM64)
+
+          ## Build artifacts
+          All native libraries have been built and tested in CI.
+          EOF
+
+          # Create PR
+          gh pr create --title "automate: Update LZ4 to ${LATEST_TAG}" --base main --head "${NEW_BRANCH_NAME}" --body-file artifacts/pr_body.txt

--- a/.github/workflows/build-native-lz4.yaml
+++ b/.github/workflows/build-native-lz4.yaml
@@ -13,6 +13,54 @@ jobs:
   #   - サブモジュールを更新したコミット
   #   - ビルドした成果物をsrc/NativeCompressions.LZ4.Runtime/runtimesに配置
 
+  check_new_release:
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      needs_update: ${{ steps.check.outputs.needs_update }}
+      latest_tag: ${{ steps.check.outputs.latest_tag }}
+      latest_commit: ${{ steps.check.outputs.latest_commit }}
+    steps:
+      - uses: Cysharp/Actions/.github/actions/checkout@main
+        with:
+          submodules: recursive
+          fetch-depth: 1
+      - name: Check lz4 latest release
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: lz4/lz4
+        run: |
+          # Get latest release tag
+          LATEST_TAG=$(gh release view --json tagName -q '.tagName')
+          LATEST_COMMIT=$(gh api "repos/${GH_REPO}/git/refs/tags/$LATEST_TAG" --jq '.object.sha')
+
+          # Get current submodule tag (if exists)
+          cd lz4
+            CURRENT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
+            CURRENT_COMMIT=$(git rev-parse HEAD)
+          cd ..
+
+          echo "latest_tag=$LATEST_TAG" | tee -a "$GITHUB_OUTPUT"
+          echo "latest_commit=$LATEST_COMMIT" | tee -a "$GITHUB_OUTPUT"
+
+          echo "Current: $CURRENT_TAG ($CURRENT_COMMIT)"
+          echo "Latest:  $LATEST_TAG ($LATEST_COMMIT)"
+
+          # Compare by tag first, fallback to commit
+          if [ "$CURRENT_TAG" = "$LATEST_TAG" ]; then
+            echo "needs_update=false" | tee -a "$GITHUB_OUTPUT"
+            echo "Already up to date: $CURRENT_TAG"
+          elif [ "$CURRENT_COMMIT" != "$LATEST_COMMIT" ]; then
+            echo "needs_update=true" | tee -a "$GITHUB_OUTPUT"
+            echo "Update needed: $CURRENT_TAG -> $LATEST_TAG"
+          else
+            echo "needs_update=false" | tee -a "$GITHUB_OUTPUT"
+            echo "Already up to date: $CURRENT_COMMIT"
+          fi
+
   build-windows:
     strategy:
       matrix:

--- a/.github/workflows/build-native-lz4.yaml
+++ b/.github/workflows/build-native-lz4.yaml
@@ -65,6 +65,7 @@ jobs:
 
   build-windows:
     needs: [check_new_release]
+    if: ${{ needs.check_new_release.outputs.needs_update == 'true' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         arch: [x64]
@@ -118,6 +119,7 @@ jobs:
 
   build-windows-arm64:
     needs: [check_new_release]
+    if: ${{ needs.check_new_release.outputs.needs_update == 'true' || github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: read
     runs-on: ubuntu-24.04
@@ -156,6 +158,7 @@ jobs:
 
   build-linux:
     needs: [check_new_release]
+    if: ${{ needs.check_new_release.outputs.needs_update == 'true' || github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: read
     runs-on: ubuntu-24.04
@@ -212,6 +215,7 @@ jobs:
 
   build-macos:
     needs: [check_new_release]
+    if: ${{ needs.check_new_release.outputs.needs_update == 'true' || github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: read
     strategy:
@@ -262,7 +266,8 @@ jobs:
           path: artifacts/osx-${{ matrix.arch }}/*
 
   package-all:
-    needs: [build-windows, build-windows-arm64, build-linux, build-macos]
+    needs: [check_new_release, build-windows, build-windows-arm64, build-linux, build-macos]
+    if: ${{ needs.check_new_release.outputs.needs_update == 'true' || github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: write
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-native-lz4.yaml
+++ b/.github/workflows/build-native-lz4.yaml
@@ -394,11 +394,13 @@ jobs:
           This PR updates LZ4 to the latest release `${{ needs.check_new_release.outputs.latest_tag }}` ([${{ needs.check_new_release.outputs.latest_commit }}](https://github.com/lz4/lz4/commit/${{ needs.check_new_release.outputs.latest_commit }}))
 
           ## Changes
-          - Updated LZ4 submodule to ${LATEST_TAG}
+          - Updated LZ4 submodule to ${{ needs.check_new_release.outputs.latest_tag }}
           - Updated native libraries for all platforms (Windows x64/ARM64, Linux x64/ARM64, macOS x64/ARM64)
 
           ## Build artifacts
           All native libraries have been built and tested in CI.
+
+          @neuecc
           EOF
 
           # Create PR

--- a/.github/workflows/build-native-lz4.yaml
+++ b/.github/workflows/build-native-lz4.yaml
@@ -1,8 +1,18 @@
+# Follow LZ4 latest release by cron update
 name: Build-Native-LZ4
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
 
 jobs:
+  # LZ4の更新をチェック - submoduleのcommit id を見て、最新リリースのコミットと比較
+  # 変化なければシカト
+  # 変化あれば、各ビルドジョブにてcheckout後にsubmoduleを更新、ビルドして成果物をアップロード
+  # ブランチを切って、PRを作成する。LZ4のリリースごとに別のPRが望ましい。(1つのPRにして更新するのは避ける)
+  # PRは以下を含む
+  #   - サブモジュールを更新したコミット
+  #   - ビルドした成果物をsrc/NativeCompressions.LZ4.Runtime/runtimesに配置
+
   build-windows:
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

This PR introduces automated LZ4 build runtime updates when new LZ4 releases are published. The action runs on a schedule daily at 3AM UTC, providing fully automated runtime updates.

- Updates submodule reference to the latest LZ4 tag.
- Builds LZ4 dynamic library runtimes for each platform and replaces current libraries.

NOTE:

- If schedule execution not detect new LZ4 release, then LZ4 build will be skipped. On other hands, workflow_dispatch still build even if LZ4 is already latest.

## Execution Test

* Scenario 1: Current LZ4 = 1.10.0, Latest LZ4 = 1.10.0, then no update detected.

https://github.com/Cysharp/NativeCompressions/actions/runs/17426732014 

* Scenario 2: Current LZ4 = 1.9.4, Latest LZ4 = 1.10.0, then update runtimes and create PR.
https://github.com/Cysharp/NativeCompressions/pull/22

<img width="942" height="838" alt="image" src="https://github.com/user-attachments/assets/b3b7d1aa-e070-442a-98c1-3596c2648f60" />