### PR TITLE
ci: zstd native build to optimize for release build

### DIFF
--- a/.github/workflows/build-native-zstd.yaml
+++ b/.github/workflows/build-native-zstd.yaml
@@ -114,7 +114,7 @@ jobs:
         shell: msys2 {0}
         run: |
           cd zstd/lib
-          make lib-release TARGET_SYSTEM=Windows CC=gcc MOREFLAGS="-DZSTD_MULTITHREAD -flto" -j$(nproc)
+          make lib-release TARGET_SYSTEM=Windows CC=gcc MOREFLAGS="-DZSTD_MULTITHREAD" -j$(nproc)
       - name: Prepare artifacts
         shell: pwsh
         run: |
@@ -152,7 +152,7 @@ jobs:
           docker run --rm -v "$PWD:/work" \
             mstorsjo/llvm-mingw:latest \
             bash -c "cd /work/zstd/lib && \
-              make lib-release TARGET_SYSTEM=Windows CC=aarch64-w64-mingw32-gcc MOREFLAGS='-DZSTD_MULTITHREAD -flto'"
+              make lib-release TARGET_SYSTEM=Windows CC=aarch64-w64-mingw32-gcc MOREFLAGS='-DZSTD_MULTITHREAD'"
           file zstd/lib/dll/libzstd.dll
       - name: Prepare artifacts
         run: |

--- a/.github/workflows/build-native-zstd.yaml
+++ b/.github/workflows/build-native-zstd.yaml
@@ -108,13 +108,13 @@ jobs:
           install: >-
             ${{ matrix.arch == 'x64' && 'mingw-w64-x86_64-gcc mingw-w64-x86_64-make' || 'mingw-w64-clang-aarch64-gcc mingw-w64-clang-aarch64-make' }}
             make
+      # Windows lib-mt-release build not apply -DZSTD_MULTITHREAD, so use lib-release instead + `MOREFLAGS="-DZSTD_MULTITHREAD -flto"`
+      # `-fPIC` is not needed on Windows
       - name: Build DLL
         shell: msys2 {0}
         run: |
-          cd zstd
-          make -C lib libzstd CC=gcc CFLAGS="-O3 -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes -Wundef -Wpointer-arith -Wvla -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings -Wredundant-decls -Wmissing-prototypes -Wc++-compat -DZSTD_MULTITHREAD" TARGET_SYSTEM=Windows
-          ls -la lib/dll/*.dll
-          file lib/dll/*.dll
+          cd zstd/lib
+          make lib-release TARGET_SYSTEM=Windows CC=gcc MOREFLAGS="-DZSTD_MULTITHREAD -flto" -j$(nproc)
       - name: Prepare artifacts
         shell: pwsh
         run: |
@@ -145,12 +145,14 @@ jobs:
             git checkout ${{ needs.check_new_release.outputs.latest_tag }}
           cd ..
           echo "Updated zstd submodule to ${{ needs.check_new_release.outputs.latest_tag }}"
+      # Windows lib-mt-release build not apply -DZSTD_MULTITHREAD, so use lib-release instead + `MOREFLAGS="-DZSTD_MULTITHREAD -flto"`
+      # `-fPIC` is not needed on Windows
       - name: Build using Docker
         run: |
           docker run --rm -v "$PWD:/work" \
             mstorsjo/llvm-mingw:latest \
-            bash -c "cd /work/zstd && \
-              make -C lib libzstd CC=aarch64-w64-mingw32-gcc CFLAGS='-O3 -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes -Wundef -Wpointer-arith -Wvla -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings -Wredundant-decls -Wmissing-prototypes -Wc++-compat' CFLAGS="-DZSTD_MULTITHREAD" TARGET_SYSTEM=Windows"
+            bash -c "cd /work/zstd/lib && \
+              make lib-release TARGET_SYSTEM=Windows CC=aarch64-w64-mingw32-gcc MOREFLAGS='-DZSTD_MULTITHREAD -flto'"
           file zstd/lib/dll/libzstd.dll
       - name: Prepare artifacts
         run: |
@@ -192,16 +194,16 @@ jobs:
           cd ..
           echo "Updated zstd submodule to ${{ needs.check_new_release.outputs.latest_tag }}"
       - name: Install ARM64 cross-compiler
-        if: matrix.arch == 'arm64'
+        if: ${{ matrix.arch == 'arm64' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y ${{ matrix.packages }}
       - name: Build shared library
         run: |
-          cd zstd
-          make -C lib libzstd CC="${{ matrix.cc }}" CFLAGS="-O3 -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes -Wundef -Wpointer-arith -Wvla -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings -Wredundant-decls -Wmissing-prototypes -Wc++-compat -fPIC -DZSTD_MULTITHREAD"
-          ls -la lib/*.so*
-          file lib/libzstd.so*
+          cd zstd/lib
+          make lib-release CC="${{ matrix.cc }}" MOREFLAGS="-DZSTD_MULTITHREAD -fPIC -flto" -j$(nproc)
+          ls -la *.so*
+          file libzstd.so*
       - name: Prepare artifacts
         run: |
           mkdir -p artifacts/linux-${{ matrix.arch }}
@@ -246,9 +248,9 @@ jobs:
           echo "Updated zstd submodule to ${{ needs.check_new_release.outputs.latest_tag }}"
       - name: Build dynamic library
         run: |
-          cd zstd
-          make -C lib libzstd CFLAGS="${{ matrix.flags }} -O3 -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes -Wundef -Wpointer-arith -Wvla -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings -Wredundant-decls -Wmissing-prototypes -Wc++-compat -DZSTD_MULTITHREAD"
-          lipo -info lib/*.dylib
+          cd zstd/lib
+          make lib-release MOREFLAGS="-DZSTD_MULTITHREAD ${{ matrix.flags }} -fPIC -flto" -j$(sysctl -n hw.ncpu)
+          lipo -info *.dylib
       - name: Prepare artifacts
         run: |
           mkdir -p artifacts/osx-${{ matrix.arch }}
@@ -281,11 +283,11 @@ jobs:
           - arch: arm64
             sdk: iphoneos
             target: aarch64-apple-ios11.0
-            cflags: "-arch arm64 -mios-version-min=11.0"
+            flags: "-arch arm64 -mios-version-min=11.0"
           - arch: x86_64
             sdk: iphonesimulator
             target: x86_64-apple-ios11.0-simulator
-            cflags: "-arch x86_64 -mios-simulator-version-min=11.0"
+            flags: "-arch x86_64 -mios-simulator-version-min=11.0"
     steps:
       - uses: Cysharp/Actions/.github/actions/checkout@main
         with:
@@ -299,17 +301,19 @@ jobs:
             git checkout ${{ needs.check_new_release.outputs.latest_tag }}
           cd ..
           echo "Updated zstd submodule to ${{ needs.check_new_release.outputs.latest_tag }}"
+      # `lib-release + -DZSTD_MULTITHREAD` build single-threaded static lib, so use `lib-mt + -O3` instead
+      # -fPIC is not needed on static library
       - name: Build static library for iOS
         run: |
           SDK_PATH=$(xcrun --sdk ${{ matrix.sdk }} --show-sdk-path)
 
           # Build static library (iOS App Store requires static linking)
-          cd zstd
-          make lib-mt CC="clang" CFLAGS="-O3 -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes -Wundef -Wpointer-arith -Wvla -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings -Wredundant-decls -Wmissing-prototypes -Wc++-compat -DZSTD_MULTITHREAD ${{ matrix.cflags }} -isysroot $SDK_PATH"
+          cd zstd/lib
+          make lib-mt CC="clang" CFLAGS="-O3 ${{ matrix.flags }} -flto -isysroot $SDK_PATH" DEBUGFLAGS="" -j$(sysctl -n hw.ncpu)
 
-          ls -la lib/libzstd.a
-          file lib/libzstd.a
-          lipo -info lib/libzstd.a
+          ls -la libzstd.a
+          file libzstd.a
+          lipo -info libzstd.a
       - name: Prepare artifacts
         run: |
           mkdir -p artifacts/ios-${{ matrix.arch }}
@@ -365,11 +369,10 @@ jobs:
       - name: Build shared library for Android
         run: |
           export PATH="${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
-
-          cd zstd
-          make -C lib libzstd CC="${{ matrix.cc }}" CFLAGS="-O3 -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes -Wundef -Wpointer-arith -Wvla -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings -Wredundant-decls -Wmissing-prototypes -Wc++-compat -DZSTD_MULTITHREAD -fPIC"
-          ls -la lib/libzstd.so*
-          file lib/libzstd.so*
+          cd zstd/lib
+          make lib-release CC="${{ matrix.cc }}" MOREFLAGS="-DZSTD_MULTITHREAD -fPIC -flto" -j$(nproc)
+          ls -la libzstd.so*
+          file libzstd.so*
       - name: Prepare artifacts
         run: |
           mkdir -p artifacts/android-${{ matrix.arch }}

--- a/.github/workflows/build-native-zstd.yaml
+++ b/.github/workflows/build-native-zstd.yaml
@@ -114,7 +114,7 @@ jobs:
         shell: msys2 {0}
         run: |
           cd zstd/lib
-          make lib-release TARGET_SYSTEM=Windows CC=gcc MOREFLAGS="-DZSTD_MULTITHREAD -flto -march=native -mtune=native" -j$(nproc)
+          make lib-release TARGET_SYSTEM=Windows CC=gcc MOREFLAGS="-DZSTD_MULTITHREAD -flto" -j$(nproc)
       - name: Prepare artifacts
         shell: pwsh
         run: |
@@ -147,7 +147,6 @@ jobs:
           echo "Updated zstd submodule to ${{ needs.check_new_release.outputs.latest_tag }}"
       # Windows lib-mt-release build not apply -DZSTD_MULTITHREAD, so use lib-release instead + `MOREFLAGS="-DZSTD_MULTITHREAD -flto"`
       # `-fPIC` is not needed on Windows
-      # `-march=native -mtune=native` is not applicable for cross compile
       - name: Build using Docker
         run: |
           docker run --rm -v "$PWD:/work" \
@@ -178,11 +177,9 @@ jobs:
         include:
           - arch: x64
             cc: gcc
-            flag: "-march=native -mtune=native"
           - arch: arm64
             cc: aarch64-linux-gnu-gcc
             packages: gcc-aarch64-linux-gnu
-            flag: "" # -march=native -mtune=native is not applicable for cross compile
     steps:
       - uses: Cysharp/Actions/.github/actions/checkout@main
         with:
@@ -204,7 +201,7 @@ jobs:
       - name: Build shared library
         run: |
           cd zstd/lib
-          make lib-release CC="${{ matrix.cc }}" MOREFLAGS="-DZSTD_MULTITHREAD -fPIC -flto ${{ matrix.flag }}" -j$(nproc)
+          make lib-release CC="${{ matrix.cc }}" MOREFLAGS="-DZSTD_MULTITHREAD -fPIC -flto" -j$(nproc)
           ls -la *.so*
           file libzstd.so*
       - name: Prepare artifacts
@@ -232,9 +229,9 @@ jobs:
         arch: [x64, arm64]
         include:
           - arch: x64
-            flags: "-arch x86_64" # -march=native -mtune=native is not applicable for cross compile
+            flags: "-arch x86_64"
           - arch: arm64
-            flags: "-arch arm64 -march=native -mtune=native"
+            flags: "-arch arm64"
     runs-on: macos-15
     timeout-minutes: 5
     steps:
@@ -306,7 +303,6 @@ jobs:
           echo "Updated zstd submodule to ${{ needs.check_new_release.outputs.latest_tag }}"
       # `lib-release + -DZSTD_MULTITHREAD` build single-threaded static lib, so use `lib-mt + -O3` instead
       # -fPIC is not needed on static library
-      # -march=native -mtune=native is not applicable for cross compile
       - name: Build static library for iOS
         run: |
           SDK_PATH=$(xcrun --sdk ${{ matrix.sdk }} --show-sdk-path)
@@ -370,7 +366,6 @@ jobs:
         with:
           ndk-version: r26d
           add-to-path: false
-      # `-march=native -mtune=native` is not applicable for cross compile
       - name: Build shared library for Android
         run: |
           export PATH="${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"

--- a/.github/workflows/build-native-zstd.yaml
+++ b/.github/workflows/build-native-zstd.yaml
@@ -114,7 +114,7 @@ jobs:
         shell: msys2 {0}
         run: |
           cd zstd/lib
-          make lib-release TARGET_SYSTEM=Windows CC=gcc MOREFLAGS="-DZSTD_MULTITHREAD -flto" -j$(nproc)
+          make lib-release TARGET_SYSTEM=Windows CC=gcc MOREFLAGS="-DZSTD_MULTITHREAD -flto -march=native -mtune=native" -j$(nproc)
       - name: Prepare artifacts
         shell: pwsh
         run: |
@@ -147,6 +147,7 @@ jobs:
           echo "Updated zstd submodule to ${{ needs.check_new_release.outputs.latest_tag }}"
       # Windows lib-mt-release build not apply -DZSTD_MULTITHREAD, so use lib-release instead + `MOREFLAGS="-DZSTD_MULTITHREAD -flto"`
       # `-fPIC` is not needed on Windows
+      # `-march=native -mtune=native` is not applicable for cross compile
       - name: Build using Docker
         run: |
           docker run --rm -v "$PWD:/work" \
@@ -177,9 +178,11 @@ jobs:
         include:
           - arch: x64
             cc: gcc
+            flag: "-march=native -mtune=native"
           - arch: arm64
             cc: aarch64-linux-gnu-gcc
             packages: gcc-aarch64-linux-gnu
+            flag: "" # -march=native -mtune=native is not applicable for cross compile
     steps:
       - uses: Cysharp/Actions/.github/actions/checkout@main
         with:
@@ -201,7 +204,7 @@ jobs:
       - name: Build shared library
         run: |
           cd zstd/lib
-          make lib-release CC="${{ matrix.cc }}" MOREFLAGS="-DZSTD_MULTITHREAD -fPIC -flto" -j$(nproc)
+          make lib-release CC="${{ matrix.cc }}" MOREFLAGS="-DZSTD_MULTITHREAD -fPIC -flto ${{ matrix.flag }}" -j$(nproc)
           ls -la *.so*
           file libzstd.so*
       - name: Prepare artifacts
@@ -229,9 +232,9 @@ jobs:
         arch: [x64, arm64]
         include:
           - arch: x64
-            flags: "-arch x86_64"
+            flags: "-arch x86_64" # -march=native -mtune=native is not applicable for cross compile
           - arch: arm64
-            flags: "-arch arm64"
+            flags: "-arch arm64 -march=native -mtune=native"
     runs-on: macos-15
     timeout-minutes: 5
     steps:
@@ -303,6 +306,7 @@ jobs:
           echo "Updated zstd submodule to ${{ needs.check_new_release.outputs.latest_tag }}"
       # `lib-release + -DZSTD_MULTITHREAD` build single-threaded static lib, so use `lib-mt + -O3` instead
       # -fPIC is not needed on static library
+      # -march=native -mtune=native is not applicable for cross compile
       - name: Build static library for iOS
         run: |
           SDK_PATH=$(xcrun --sdk ${{ matrix.sdk }} --show-sdk-path)
@@ -366,6 +370,7 @@ jobs:
         with:
           ndk-version: r26d
           add-to-path: false
+      # `-march=native -mtune=native` is not applicable for cross compile
       - name: Build shared library for Android
         run: |
           export PATH="${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"


### PR DESCRIPTION
## Summary

Thank you to the https://github.com/Cysharp/NativeCompressions/pull/36 that our zstd compile option is not optimized for release. With fully respect suggested change, we further research zstd release build options. This brings Comprehensive optimization of ZSTD native library build settings to significantly improve performance across all platforms than Debug build.

Benchmark with newly build libs, there are same performance as PR. I believe it's optimized for release.

Benchmark on AMD Ryzen 7 5800H with Radeon Graphics 3.20GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 10.0.100-rc.1.25451.107

main (after #36)

<img width="1028" height="178" alt="image" src="https://github.com/user-attachments/assets/562c47a6-a6be-4b99-9200-18290ea31c0a" />

pr

<img width="992" height="175" alt="image" src="https://github.com/user-attachments/assets/750737fa-2b12-4052-8c1b-b6cbf1da5101" />

## Summarize build options

```
# Windows (dynamic lib):
make lib-release MOREFLAGS="-DZSTD_MULTITHREAD"

# Linux (dynamic lib):
make lib-release MOREFLAGS="-DZSTD_MULTITHREAD -fPIC -flto"

# macOS (dynamic lib):
make lib-release MOREFLAGS="-DZSTD_MULTITHREAD -fPIC -flto"

# Android (dynamic lib):
make lib-release MOREFLAGS="-DZSTD_MULTITHREAD -fPIC -flto"

# iOS (static lib):
make lib-mt CFLAGS="-O3 -flto -isysroot $SDK_PATH" 
```

## What changed

### 1. **Unified Release Optimization**
- Use `lib-release` target across all platforms, expect iOS. (previously debug target `libzstd` was used)
  - for iOS, added `-O 3` for optimize option added by `lib-release`
-  Use `MOREFLAGS` instead of `CFLAGS` to keep optimization flags added by lib-release.
- Complete removal of debug flags with `DEBUGFLAGS=""`
- Eliminate compilation time overhead from warning flags (previously debug options are fully added, we suppose performance so they should removed)

### 2. **Consistent Multi-threading Support**
- Explicitly specify `-DZSTD_MULTITHREAD` on all platforms (keep previous}
- Ensure multi-threading is enabled even for static libraries (iOS). (We need specify `lib-mt` target, so added `-O 3` for release optimization)

### 3. **Link Time Optimization (LTO)** (applied to Linux, macOS, iOS, Android)

- Apply `-flto` across all platforms (Previously it was missing)
- Achieve 5-15% performance improvement
- LTO disabled on Windows x64/ARM64. LTO on Windows MingW gcc environment brings draw back on MSVC environment, therefore LTO is disabled on Windows.  NativeCompressions_Zstandard_Compress_Default 920ms -> 970ms, NativeCompressions_Zstandard_Compress_Minus4 354ms -> 377ms, NativeCompressions_Zstandard_Compress_Multithread 258ms -> 290ms.

### 4. **Proper Position Independent Code (PIC) Usage**
- Shared libraries (Linux/Android/macOS): `-fPIC` required
- Static libraries (iOS): `-fPIC` not needed
- Windows DLL: Uses native mechanism, `-fPIC` not required

### Tried but reverted

### **Native CPU Optimization** (applied to Win-x64, Linux-x64, macOS-arm64)
- Add `-march=native -mtune=native` for native builds (Previously it was missing)
- Exclude for cross-compilation to prioritize compatibility

zstd build was succeeded but Windows Benchmark failed with generated libzstd. This might be CPU subset won't supported on local machine, Ryzen 7 5800H. Build with this options means libzstd restricted into CI VM Machine's CPU subset.
