### PR TITLE
chore: Specify IsPackable=false on Directory.Build.props, explicitly true for target packages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,19 @@ publish
 *.Publish.xml
 
 # NuGet Packages Directory
+*.nupkg
+# NuGet Symbol Packages
+*.snupkg
+# The packages folder can be ignored because of Package Restore
 # packages # upm pacakge will use Packages
+**/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
 
 # Windows Azure Build Output
 csx
@@ -107,9 +119,6 @@ UpgradeLog*.XML
 .vs/config/applicationhost.config
 .vs/restore.dg
 
-nuget/tools/*
-nuget/*.nupkg
-nuget/*.unitypackage
 .vs/
 
 # Jetbrains Rider

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,28 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<PropertyGroup>
-		<LangVersion>14</LangVersion>
-		<Nullable>enable</Nullable>
+  <PropertyGroup>
+    <LangVersion>14</LangVersion>
+    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ImplicitUsings>enable</ImplicitUsings>
-		<UseArtifactsOutput>true</UseArtifactsOutput>
-		
-		<!-- NuGet Package Information -->
-		<PackageVersion>$(Version)</PackageVersion>
-		<Company>Cysharp</Company>
-		<Authors>Cysharp</Authors>
-		<Copyright>© Cysharp, Inc.</Copyright>
-		<PackageTags>compression, native</PackageTags>
-		<PackageProjectUrl>https://github.com/Cysharp/NativeCompressions</PackageProjectUrl>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageIcon>Icon.png</PackageIcon>
-	</PropertyGroup>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
 
-	<ItemGroup>
-		<None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
-		<None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="\" />
-	</ItemGroup>
+    <!-- NuGet Package Information -->
+    <IsPackable>false</IsPackable>
+    <PackageVersion>$(Version)</PackageVersion>
+    <Company>Cysharp</Company>
+    <Authors>Cysharp</Authors>
+    <Copyright>© Cysharp, Inc.</Copyright>
+    <PackageTags>compression, native</PackageTags>
+    <PackageProjectUrl>https://github.com/Cysharp/NativeCompressions</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageIcon>Icon.png</PackageIcon>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="\" />
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)LICENSE" />
+  </ItemGroup>
 </Project>

--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -8,7 +8,6 @@
     <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>
     <TieredPGO>true</TieredPGO>
-    <IsPackable>false</IsPackable>
     <NoWarn>CS8600;CS8604;NU1608</NoWarn>
   </PropertyGroup>
 

--- a/sandbox/ConsoleApplication/ConsoleApplication.csproj
+++ b/sandbox/ConsoleApplication/ConsoleApplication.csproj
@@ -1,32 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net9.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-		<IsPackable>false</IsPackable>
-		<ImplicitUsings>disable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<Compile Include="..\..\tests\NativeCompressions.Tests\NativeMethodsLoader.cs" Link="NativeMethodsLoader.cs" />
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\tests\NativeCompressions.Tests\NativeMethodsLoader.cs" Link="NativeMethodsLoader.cs" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Include="..\..\resources\silesia.tar.lz4" Link="silesia.tar.lz4">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\resources\silesia.tar.lz4" Link="silesia.tar.lz4">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
-	<ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\NativeCompressions.LZ4.csproj" />
     <ProjectReference Include="..\..\src\NativeCompressions.Zstandard.csproj" />
-	</ItemGroup>
+  </ItemGroup>
 
-	<!--<PackageReference Include="K4os.Compression.LZ4" Version="1.3.5" />
-		<PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.3.5" />-->
-	<!--<PackageReference Include="ZstdNet" Version="1.4.5" />-->
+  <!--<PackageReference Include="K4os.Compression.LZ4" Version="1.3.5" />
+    <PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.3.5" />-->
+  <!--<PackageReference Include="ZstdNet" Version="1.4.5" />-->
 </Project>

--- a/sandbox/Profiling/Profiling.csproj
+++ b/sandbox/Profiling/Profiling.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NativeCompressions.BenchmarkHelper/NativeCompressions.BenchmarkHelper.csproj
+++ b/src/NativeCompressions.BenchmarkHelper/NativeCompressions.BenchmarkHelper.csproj
@@ -7,6 +7,9 @@
     <LangVersion>latest</LangVersion>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <Description>BenchmarkDotNet helper to compare compression performance.</Description>
+
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NativeCompressions.LZ4.Core/NativeCompressions.LZ4.Core.csproj
+++ b/src/NativeCompressions.LZ4.Core/NativeCompressions.LZ4.Core.csproj
@@ -4,6 +4,9 @@
     <TargetFrameworks>netstandard2.1;net8.0;net9.0;</TargetFrameworks>
     <RootNamespace>NativeCompressions</RootNamespace>
     <Description>Core binding of native LZ4 high-performance streaming compression for .NET.</Description>
+
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.android-arm.csproj
+++ b/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.android-arm.csproj
@@ -1,20 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>LZ4 native runtime for android-arm.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>LZ4 native runtime for android-arm.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\android-arm\native\liblz4.so" PackagePath="runtimes\android-arm\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\android-arm\native\liblz4.so" PackagePath="runtimes\android-arm\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.android-arm64.csproj
+++ b/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.android-arm64.csproj
@@ -1,20 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>LZ4 native runtime for android-arm64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>LZ4 native runtime for android-arm64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\android-arm64\native\liblz4.so" PackagePath="runtimes\android-arm64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\android-arm64\native\liblz4.so" PackagePath="runtimes\android-arm64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.android-x64.csproj
+++ b/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.android-x64.csproj
@@ -1,20 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>LZ4 native runtime for android-x64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>LZ4 native runtime for android-x64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\android-x64\native\liblz4.so" PackagePath="runtimes\android-x64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\android-x64\native\liblz4.so" PackagePath="runtimes\android-x64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.csproj
+++ b/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.csproj
@@ -1,31 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>LZ4 native runtimes for NativeCompressions.LZ4.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>LZ4 native runtimes for NativeCompressions.LZ4.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="NativeCompressions.LZ4.Runtime.linux-arm64.csproj" />
-		<ProjectReference Include="NativeCompressions.LZ4.Runtime.linux-x64.csproj" />
-		<ProjectReference Include="NativeCompressions.LZ4.Runtime.osx-arm64.csproj" />
-		<ProjectReference Include="NativeCompressions.LZ4.Runtime.osx-x64.csproj" />
-		<ProjectReference Include="NativeCompressions.LZ4.Runtime.win-arm64.csproj" />
-		<ProjectReference Include="NativeCompressions.LZ4.Runtime.win-x64.csproj" />
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="NativeCompressions.LZ4.Runtime.linux-arm64.csproj" />
+    <ProjectReference Include="NativeCompressions.LZ4.Runtime.linux-x64.csproj" />
+    <ProjectReference Include="NativeCompressions.LZ4.Runtime.osx-arm64.csproj" />
+    <ProjectReference Include="NativeCompressions.LZ4.Runtime.osx-x64.csproj" />
+    <ProjectReference Include="NativeCompressions.LZ4.Runtime.win-arm64.csproj" />
+    <ProjectReference Include="NativeCompressions.LZ4.Runtime.win-x64.csproj" />
     <ProjectReference Include="NativeCompressions.LZ4.Runtime.android-arm.csproj" />
     <ProjectReference Include="NativeCompressions.LZ4.Runtime.android-arm64.csproj" />
     <ProjectReference Include="NativeCompressions.LZ4.Runtime.android-x64.csproj" />
     <ProjectReference Include="NativeCompressions.LZ4.Runtime.ios-arm64.csproj" />
     <ProjectReference Include="NativeCompressions.LZ4.Runtime.ios-x64.csproj" />
-	</ItemGroup>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.ios-arm64.csproj
+++ b/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.ios-arm64.csproj
@@ -1,20 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>LZ4 native runtime for ios-arm64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>LZ4 native runtime for ios-arm64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\ios-arm64\native\liblz4.a" PackagePath="runtimes\ios-arm64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\ios-arm64\native\liblz4.a" PackagePath="runtimes\ios-arm64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.ios-x64.csproj
+++ b/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.ios-x64.csproj
@@ -1,20 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>LZ4 native runtime for ios-x64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>LZ4 native runtime for ios-x64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\ios-x64\native\liblz4.a" PackagePath="runtimes\ios-x64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\ios-x64\native\liblz4.a" PackagePath="runtimes\ios-x64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.linux-arm64.csproj
+++ b/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.linux-arm64.csproj
@@ -1,20 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>LZ4 native runtime for linux-arm64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>LZ4 native runtime for linux-arm64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\linux-arm64\native\liblz4.so" PackagePath="runtimes\linux-arm64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\linux-arm64\native\liblz4.so" PackagePath="runtimes\linux-arm64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.linux-x64.csproj
+++ b/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.linux-x64.csproj
@@ -1,20 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>LZ4 native runtime for linux-x64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>LZ4 native runtime for linux-x64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\linux-x64\native\liblz4.so" PackagePath="runtimes\linux-x64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\linux-x64\native\liblz4.so" PackagePath="runtimes\linux-x64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.osx-arm64.csproj
+++ b/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.osx-arm64.csproj
@@ -1,20 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>LZ4 native runtime for osx-arm64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>LZ4 native runtime for osx-arm64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\osx-arm64\native\liblz4.dylib" PackagePath="runtimes\osx-arm64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\osx-arm64\native\liblz4.dylib" PackagePath="runtimes\osx-arm64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.osx-x64.csproj
+++ b/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.osx-x64.csproj
@@ -1,20 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>LZ4 native runtime for osx-x64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>LZ4 native runtime for osx-x64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\osx-x64\native\liblz4.dylib" PackagePath="runtimes\osx-x64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\osx-x64\native\liblz4.dylib" PackagePath="runtimes\osx-x64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.win-arm64.csproj
+++ b/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.win-arm64.csproj
@@ -1,20 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>LZ4 native runtime for win-arm64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>LZ4 native runtime for win-arm64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\win-arm64\native\lz4.dll" PackagePath="runtimes\win-arm64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\win-arm64\native\lz4.dll" PackagePath="runtimes\win-arm64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.win-x64.csproj
+++ b/src/NativeCompressions.LZ4.Runtime/NativeCompressions.LZ4.Runtime.win-x64.csproj
@@ -1,20 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>LZ4 native runtime for win-x64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>LZ4 native runtime for win-x64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\win-x64\native\lz4.dll" PackagePath="runtimes\win-x64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\win-x64\native\lz4.dll" PackagePath="runtimes\win-x64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.LZ4.csproj
+++ b/src/NativeCompressions.LZ4.csproj
@@ -1,24 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net8.0;net9.0;</TargetFrameworks>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Native LZ4 high-performance streaming compression for .NET.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0;</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Native LZ4 high-performance streaming compression for .NET.</Description>
 
-	<ItemGroup>
-		<None Remove="**" />
-		<Compile Remove="**" />
-		<EmbededResources Remove="**" />
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="NativeCompressions.LZ4.Core\NativeCompressions.LZ4.Core.csproj" />
-		<ProjectReference Include="NativeCompressions.LZ4.Runtime\NativeCompressions.LZ4.Runtime.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Remove="**" />
+    <Compile Remove="**" />
+    <EmbededResources Remove="**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="NativeCompressions.LZ4.Core\NativeCompressions.LZ4.Core.csproj" />
+    <ProjectReference Include="NativeCompressions.LZ4.Runtime\NativeCompressions.LZ4.Runtime.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.Zstandard.Core/NativeCompressions.Zstandard.Core.csproj
+++ b/src/NativeCompressions.Zstandard.Core/NativeCompressions.Zstandard.Core.csproj
@@ -4,6 +4,9 @@
     <TargetFrameworks>netstandard2.1;net8.0;net9.0;</TargetFrameworks>
     <RootNamespace>NativeCompressions</RootNamespace>
     <Description>Core binding of native Zstandard high-performance streaming compression for .NET.</Description>
+
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.android-arm.csproj
+++ b/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.android-arm.csproj
@@ -1,20 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Zstandard native runtime for android-arm.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Zstandard native runtime for android-arm.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\android-arm\native\libzstd.so" PackagePath="runtimes\android-arm\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\android-arm\native\libzstd.so" PackagePath="runtimes\android-arm\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.android-arm64.csproj
+++ b/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.android-arm64.csproj
@@ -1,20 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Zstandard native runtime for android-arm64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Zstandard native runtime for android-arm64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\android-arm64\native\libzstd.so" PackagePath="runtimes\android-arm64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\android-arm64\native\libzstd.so" PackagePath="runtimes\android-arm64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.android-x64.csproj
+++ b/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.android-x64.csproj
@@ -1,20 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Zstandard native runtime for android-x64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Zstandard native runtime for android-x64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\android-x64\native\libzstd.so" PackagePath="runtimes\android-x64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\android-x64\native\libzstd.so" PackagePath="runtimes\android-x64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.csproj
+++ b/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.csproj
@@ -1,31 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Zstandard native runtimes for NativeCompressions.Zstandard.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Zstandard native runtimes for NativeCompressions.Zstandard.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="NativeCompressions.Zstandard.Runtime.linux-arm64.csproj" />
-		<ProjectReference Include="NativeCompressions.Zstandard.Runtime.linux-x64.csproj" />
-		<ProjectReference Include="NativeCompressions.Zstandard.Runtime.osx-arm64.csproj" />
-		<ProjectReference Include="NativeCompressions.Zstandard.Runtime.osx-x64.csproj" />
-		<ProjectReference Include="NativeCompressions.Zstandard.Runtime.win-arm64.csproj" />
-		<ProjectReference Include="NativeCompressions.Zstandard.Runtime.win-x64.csproj" />
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="NativeCompressions.Zstandard.Runtime.linux-arm64.csproj" />
+    <ProjectReference Include="NativeCompressions.Zstandard.Runtime.linux-x64.csproj" />
+    <ProjectReference Include="NativeCompressions.Zstandard.Runtime.osx-arm64.csproj" />
+    <ProjectReference Include="NativeCompressions.Zstandard.Runtime.osx-x64.csproj" />
+    <ProjectReference Include="NativeCompressions.Zstandard.Runtime.win-arm64.csproj" />
+    <ProjectReference Include="NativeCompressions.Zstandard.Runtime.win-x64.csproj" />
     <ProjectReference Include="NativeCompressions.Zstandard.Runtime.android-arm.csproj" />
     <ProjectReference Include="NativeCompressions.Zstandard.Runtime.android-arm64.csproj" />
     <ProjectReference Include="NativeCompressions.Zstandard.Runtime.android-x64.csproj" />
     <ProjectReference Include="NativeCompressions.Zstandard.Runtime.ios-arm64.csproj" />
     <ProjectReference Include="NativeCompressions.Zstandard.Runtime.ios-x64.csproj" />
-	</ItemGroup>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.ios-arm64.csproj
+++ b/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.ios-arm64.csproj
@@ -1,20 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Zstandard native runtime for ios-arm64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Zstandard native runtime for ios-arm64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\ios-arm64\native\libzstd.a" PackagePath="runtimes\ios-arm64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\ios-arm64\native\libzstd.a" PackagePath="runtimes\ios-arm64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.ios-x64.csproj
+++ b/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.ios-x64.csproj
@@ -1,20 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Zstandard native runtime for ios-x64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Zstandard native runtime for ios-x64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\ios-x64\native\libzstd.a" PackagePath="runtimes\ios-x64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\ios-x64\native\libzstd.a" PackagePath="runtimes\ios-x64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.linux-arm64.csproj
+++ b/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.linux-arm64.csproj
@@ -1,20 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Zstandard native runtime for linux-arm64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Zstandard native runtime for linux-arm64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\linux-arm64\native\libzstd.so" PackagePath="runtimes\linux-arm64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\linux-arm64\native\libzstd.so" PackagePath="runtimes\linux-arm64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.linux-x64.csproj
+++ b/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.linux-x64.csproj
@@ -1,20 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Zstandard native runtime for linux-x64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Zstandard native runtime for linux-x64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\linux-x64\native\libzstd.so" PackagePath="runtimes\linux-x64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\linux-x64\native\libzstd.so" PackagePath="runtimes\linux-x64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.osx-arm64.csproj
+++ b/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.osx-arm64.csproj
@@ -1,20 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Zstandard native runtime for osx-arm64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Zstandard native runtime for osx-arm64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\osx-arm64\native\libzstd.dylib" PackagePath="runtimes\osx-arm64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\osx-arm64\native\libzstd.dylib" PackagePath="runtimes\osx-arm64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.osx-x64.csproj
+++ b/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.osx-x64.csproj
@@ -1,20 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Zstandard native runtime for osx-x64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Zstandard native runtime for osx-x64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\osx-x64\native\libzstd.dylib" PackagePath="runtimes\osx-x64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\osx-x64\native\libzstd.dylib" PackagePath="runtimes\osx-x64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.win-arm64.csproj
+++ b/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.win-arm64.csproj
@@ -1,20 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Zstandard native runtime for win-arm64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Zstandard native runtime for win-arm64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\win-arm64\native\libzstd.dll" PackagePath="runtimes\win-arm64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\win-arm64\native\libzstd.dll" PackagePath="runtimes\win-arm64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.win-x64.csproj
+++ b/src/NativeCompressions.Zstandard.Runtime/NativeCompressions.Zstandard.Runtime.win-x64.csproj
@@ -1,20 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Zstandard native runtime for win-x64.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Zstandard native runtime for win-x64.</Description>
 
-	<ItemGroup>
-		<None Remove="runtimes\**" />
-		<None Include="runtimes\win-x64\native\libzstd.dll" PackagePath="runtimes\win-x64\native\" Pack="true">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="runtimes\**" />
+    <None Include="runtimes\win-x64\native\libzstd.dll" PackagePath="runtimes\win-x64\native\" Pack="true">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.Zstandard.csproj
+++ b/src/NativeCompressions.Zstandard.csproj
@@ -1,24 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net8.0;net9.0;</TargetFrameworks>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Native Zstandard high-performance streaming compression for .NET.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0;</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Native Zstandard high-performance streaming compression for .NET.</Description>
 
-	<ItemGroup>
-		<None Remove="**" />
-		<Compile Remove="**" />
-		<EmbededResources Remove="**" />
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="NativeCompressions.Zstandard.Core\NativeCompressions.Zstandard.Core.csproj" />
-		<ProjectReference Include="NativeCompressions.Zstandard.Runtime\NativeCompressions.Zstandard.Runtime.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Remove="**" />
+    <Compile Remove="**" />
+    <EmbededResources Remove="**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="NativeCompressions.Zstandard.Core\NativeCompressions.Zstandard.Core.csproj" />
+    <ProjectReference Include="NativeCompressions.Zstandard.Runtime\NativeCompressions.Zstandard.Runtime.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/NativeCompressions.csproj
+++ b/src/NativeCompressions.csproj
@@ -1,24 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net8.0;net9.0;</TargetFrameworks>
-		<Nullable>enable</Nullable>
-		<!-- Not include this dll, only native dlls. -->
-		<IncludeBuildOutput>false</IncludeBuildOutput>
-		<IncludeContentInPack>true</IncludeContentInPack>
-		<NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-		<Description>Native LZ4/Zstandard high-performance streaming compression for .NET.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0;</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <!-- Not include this dll, only native dlls. -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
+    <Description>Native LZ4/Zstandard high-performance streaming compression for .NET.</Description>
 
-	<ItemGroup>
-		<None Remove="**" />
-		<Compile Remove="**" />
-		<EmbededResources Remove="**" />
-	</ItemGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="NativeCompressions.LZ4.csproj" />
-		<ProjectReference Include="NativeCompressions.Zstandard.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Remove="**" />
+    <Compile Remove="**" />
+    <EmbededResources Remove="**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="NativeCompressions.LZ4.csproj" />
+    <ProjectReference Include="NativeCompressions.Zstandard.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/tests/NativeCompressions.Tests/NativeCompressions.Tests.csproj
+++ b/tests/NativeCompressions.Tests/NativeCompressions.Tests.csproj
@@ -1,34 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
-		<IsTestProject>true</IsTestProject>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.11.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\NativeCompressions.LZ4.csproj" />
-		<ProjectReference Include="..\..\src\NativeCompressions.Zstandard.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NativeCompressions.LZ4.csproj" />
+    <ProjectReference Include="..\..\src\NativeCompressions.Zstandard.csproj" />
+  </ItemGroup>
 
 
-	<ItemGroup>
-		<Using Include="Xunit" />
-		<Using Include="Xunit.Abstractions" />
-		<Using Include="FluentAssertions" />
-	</ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
+    <Using Include="FluentAssertions" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Change IsPackable from default, implicitly `true`, to explicitly `false`.
This prevent unintended nuget package generation like sandbox, benchmark, and etc....

Side effect:

- nupkg csproj required to specify `<IsPackable>true</IsPackable>`. Previously they are omitted.
- LICENSE.md is now handled by Directory.Build.props
