### PR TITLE
LZ4 - Use Parallel.ForAsync instead Task.WhenAll when possible

### DIFF
--- a/src/NativeCompressions.LZ4.Core/LZ4.Compress.cs
+++ b/src/NativeCompressions.LZ4.Core/LZ4.Compress.cs
@@ -189,11 +189,49 @@ public static partial class LZ4
 
             // producer: slice buffer and compress, send compressed buffer.
             var bufferId = -1;
-            var outputProducers = new Task[threadCount];
-            for (int i = 0; i < outputProducers.Length; i++)
+            Task outputProducers;
+
+#if NET8_0_OR_GREATER
+            outputProducers = Parallel.ForAsync(0, threadCount, async (producerId, _) =>
+            {
+                using (LZ4ActivitySource.Start("InputCompressLoop", tagKey: "LoopId", tagValue: producerId))
+                {
+                    ActivityContext? linkContext = null;
+                    using var encoder = new LZ4Encoder(newOptions) { IsWriteHeader = false };
+                    while (true)
+                    {
+                        var id = Interlocked.Increment(ref bufferId);
+                        var offset = unchecked(id * actualChunkSize);
+                        if (offset < 0) break; // overflow
+
+                        var remaining = source.Length - offset;
+                        if (remaining <= 0) break;
+
+                        var src = source.Span.Slice(offset, Math.Min(remaining, actualChunkSize));
+                        var bufferLength = encoder.GetMaxCompressedLength(src.Length, includingHeader: false, includingFooter: false);
+                        var dest = ArrayPool<byte>.Shared.Rent(bufferLength);
+
+                        int written;
+                        using (LZ4ActivitySource.Start("Compress", ref linkContext))
+                        {
+                            written = encoder.Compress(src, dest);
+                        }
+
+                        await outputChannel.Writer.WriteAsync(new CompressionBuffer
+                        {
+                            CompressedBuffer = dest,
+                            Count = written,
+                            Id = id
+                        }, channelToken.Token);
+                    }
+                }
+            });
+#else
+            var producerTasks = new Task[threadCount];
+            for (int i = 0; i < producerTasks.Length; i++)
             {
                 var producerId = i;
-                outputProducers[i] = Task.Run(async () =>
+                producerTasks[i] = Task.Run(async () =>
                 {
                     using (LZ4ActivitySource.Start("InputCompressLoop", tagKey: "LoopId", tagValue: producerId))
                     {
@@ -229,11 +267,14 @@ public static partial class LZ4
                 });
             }
 
+            outputProducers = Task.WhenAll(producerTasks);
+#endif
+
             var outputConsumer = StartWriteCompressedBuffer(destination, newOptions, outputChannel, channelToken);
 
             try
             {
-                await Task.WhenAll(outputProducers);
+                await outputProducers;
                 outputChannel.Writer.Complete(); // all reader complete, input is finished.
                 await outputConsumer; // wait for complete flush compressed data
             }
@@ -341,10 +382,49 @@ public static partial class LZ4
 
             // producer: slice buffer and compress, send compressed buffer.
             var bufferId = -1;
-            var outputProducers = new Task[threadCount];
-            for (int i = 0; i < outputProducers.Length; i++)
+            Task outputProducers;
+#if NET8_0_OR_GREATER
+            outputProducers = Parallel.ForAsync(0, threadCount, async (producerId, _) =>
             {
-                outputProducers[i] = Task.Run(async () =>
+                using var encoder = new LZ4Encoder(newOptions) { IsWriteHeader = false };
+
+                while (true)
+                {
+                    var id = Interlocked.Increment(ref bufferId);
+                    var offset = id * actualChunkSize;
+
+                    var remaining = source.Length - offset;
+                    if (remaining <= 0)
+                    {
+                        break;
+                    }
+
+                    var src = source.Slice(offset, Math.Min(remaining, actualChunkSize));
+                    var bufferLength = encoder.GetMaxCompressedLength((int)src.Length, includingHeader: false, includingFooter: false);
+                    var destBuffer = ArrayPool<byte>.Shared.Rent(bufferLength);
+
+                    var written = 0;
+                    var dest = destBuffer.AsSpan(0, bufferLength);
+                    foreach (var item in src)
+                    {
+                        written += encoder.Compress(item.Span, dest);
+                        dest = dest.Slice(written);
+                    }
+                    written += encoder.Flush(dest); // must flush after compress ReadOnlySequence chunks
+
+                    await outputChannel.Writer.WriteAsync(new CompressionBuffer
+                    {
+                        CompressedBuffer = destBuffer,
+                        Count = written,
+                        Id = id
+                    }, channelToken.Token);
+                }
+            });
+#else
+            var producerTasks = new Task[threadCount];
+            for (int i = 0; i < producerTasks.Length; i++)
+            {
+                producerTasks[i] = Task.Run(async () =>
                 {
                     using var encoder = new LZ4Encoder(newOptions) { IsWriteHeader = false };
 
@@ -381,6 +461,9 @@ public static partial class LZ4
                     }
                 });
             }
+
+            outputProducers = Task.WhenAll(producerTasks);
+#endif
 
             var outputConsumer = StartWriteCompressedBuffer(destination, newOptions, outputChannel, channelToken);
 
@@ -510,11 +593,54 @@ public static partial class LZ4
 
             // producer: slice buffer and compress, send compressed buffer.
             var bufferId = -1;
-            var outputProducers = new Task[threadCount];
-            for (int i = 0; i < outputProducers.Length; i++)
+            Task outputProducers;
+#if NET8_0_OR_GREATER
+            var initialOffset = offset;
+
+            outputProducers = Parallel.ForAsync(0, threadCount, async (i, _) =>
+            {
+                using var encoder = new LZ4Encoder(newOptions) { IsWriteHeader = false };
+
+                var srcBuffer = ArrayPool<byte>.Shared.Rent(actualChunkSize); // src buffer rent once
+                try
+                {
+                    while (true)
+                    {
+                        var id = Interlocked.Increment(ref bufferId);
+                        var offset = initialOffset + id * (long)actualChunkSize; // long for over 2GB file
+
+                        var remaining = sourceLength - offset;
+                        if (remaining <= 0)
+                        {
+                            break;
+                        }
+
+                        var read = await RandomAccess.ReadAsync(source, srcBuffer.AsMemory(0, (int)Math.Min(remaining, actualChunkSize)), offset, channelToken.Token);
+                        var src = srcBuffer.AsSpan(0, read);
+                        var bufferLength = encoder.GetMaxCompressedLength((int)src.Length, includingHeader: false, includingFooter: false);
+                        var dest = ArrayPool<byte>.Shared.Rent(bufferLength);
+
+                        var written = encoder.Compress(src, dest); // autoFlush
+
+                        await outputChannel.Writer.WriteAsync(new CompressionBuffer
+                        {
+                            CompressedBuffer = dest,
+                            Count = written,
+                            Id = id
+                        }, channelToken.Token);
+                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(srcBuffer, clearArray: false);
+                }
+            });
+#else
+            var producerTasks = new Task[threadCount];
+            for (int i = 0; i < producerTasks.Length; i++)
             {
                 var initialOffset = offset;
-                outputProducers[i] = Task.Run(async () =>
+                producerTasks[i] = Task.Run(async () =>
                 {
                     using var encoder = new LZ4Encoder(newOptions) { IsWriteHeader = false };
 
@@ -554,6 +680,9 @@ public static partial class LZ4
                 });
             }
 
+            outputProducers = Task.WhenAll(producerTasks);
+#endif
+
             var outputConsumer = StartWriteCompressedBuffer(destination, newOptions, outputChannel, channelToken);
 
             try
@@ -569,7 +698,7 @@ public static partial class LZ4
             }
         }
 #endif
-    }
+        }
 
     public static async ValueTask CompressAsync(Stream source, PipeWriter destination, LZ4CompressionOptions? options = null, CancellationToken cancellationToken = default)
     {

--- a/src/NativeCompressions.LZ4.Core/LZ4.Decompress.cs
+++ b/src/NativeCompressions.LZ4.Core/LZ4.Decompress.cs
@@ -209,13 +209,13 @@ public static partial class LZ4
                 inputChannel.Writer.Complete();
             });
 
-            Task[] inputConsumerOutputProducers = StartDecompressBlock(options?.Dictionary, maxBlockSize, threadCount, inputChannel, outputChannel, channelToken);
+            Task inputConsumerOutputProducers = StartDecompressBlock(options?.Dictionary, maxBlockSize, threadCount, inputChannel, outputChannel, channelToken);
             Task outputConsumer = StartWriteDecompressedBuffer(destination, outputChannel, channelToken);
 
             try
             {
                 await inputProducer;
-                await Task.WhenAll(inputConsumerOutputProducers);
+                await inputConsumerOutputProducers;
                 outputChannel.Writer.Complete();
                 await outputConsumer;
             }
@@ -354,13 +354,13 @@ public static partial class LZ4
                 inputChannel.Writer.Complete();
             });
 
-            Task[] inputConsumerOutputProducers = StartDecompressBlock(options?.Dictionary, maxBlockSize, threadCount, inputChannel, outputChannel, channelToken);
+            Task inputConsumerOutputProducers = StartDecompressBlock(options?.Dictionary, maxBlockSize, threadCount, inputChannel, outputChannel, channelToken);
             Task outputConsumer = StartWriteDecompressedBuffer(destination, outputChannel, channelToken);
 
             try
             {
                 await inputProducer;
-                await Task.WhenAll(inputConsumerOutputProducers);
+                await inputConsumerOutputProducers;
                 outputChannel.Writer.Complete();
                 await outputConsumer;
             }
@@ -560,13 +560,13 @@ public static partial class LZ4
                 }
             });
 
-            Task[] inputConsumerOutputProducers = StartDecompressBlock(options?.Dictionary, maxBlockSize, threadCount, inputChannel, outputChannel, channelToken);
+            Task inputConsumerOutputProducers = StartDecompressBlock(options?.Dictionary, maxBlockSize, threadCount, inputChannel, outputChannel, channelToken);
             Task outputConsumer = StartWriteDecompressedBuffer(destination, outputChannel, channelToken);
 
             try
             {
                 await inputProducer;
-                await Task.WhenAll(inputConsumerOutputProducers);
+                await inputConsumerOutputProducers;
                 outputChannel.Writer.Complete();
                 await outputConsumer;
             }
@@ -754,13 +754,13 @@ public static partial class LZ4
                 inputChannel.Writer.Complete();
             });
 
-            Task[] inputConsumerOutputProducers = StartDecompressBlock(options?.Dictionary, maxBlockSize, threadCount, inputChannel, outputChannel, channelToken);
+            Task inputConsumerOutputProducers = StartDecompressBlock(options?.Dictionary, maxBlockSize, threadCount, inputChannel, outputChannel, channelToken);
             Task outputConsumer = StartWriteDecompressedBuffer(destination, outputChannel, channelToken);
 
             try
             {
                 await inputProducer;
-                await Task.WhenAll(inputConsumerOutputProducers);
+                await inputConsumerOutputProducers;
                 outputChannel.Writer.Complete();
                 await outputConsumer;
             }
@@ -813,12 +813,50 @@ public static partial class LZ4
         return outputConsumer;
     }
 
-    static Task[] StartDecompressBlock(LZ4Dictionary? dictionary, int maxBlockSize, int threadCount, Channel<DecompressionInputBuffer> inputChannel, Channel<DecompressionOutputBuffer> outputChannel, CancellationTokenSource channelToken)
+    static Task StartDecompressBlock(LZ4Dictionary? dictionary, int maxBlockSize, int threadCount, Channel<DecompressionInputBuffer> inputChannel, Channel<DecompressionOutputBuffer> outputChannel, CancellationTokenSource channelToken)
     {
-        var inputConsumerOutputProducers = new Task[threadCount];
-        for (var i = 0; i < inputConsumerOutputProducers.Length; i++)
+        Task inputConsumerOutputProducers;
+#if NET8_0_OR_GREATER
+        inputConsumerOutputProducers = Parallel.ForAsync(0, threadCount, async (i, _) =>
         {
-            inputConsumerOutputProducers[i] = Task.Run(async () =>
+            while (await inputChannel.Reader.WaitToReadAsync(channelToken.Token))
+            {
+                while (inputChannel.Reader.TryRead(out var item))
+                {
+                    var destination = ArrayPool<byte>.Shared.Rent(maxBlockSize);
+                    int written;
+                    if (item.IsUncompressed)
+                    {
+                        item.CompressedBuffer.CopyTo(destination);
+                        written = item.CompressedBuffer.Length;
+                    }
+                    else
+                    {
+                        // use LZ4 raw block decompress
+                        written = LZ4.Block.Decompress(item.CompressedBuffer.Span, destination, dictionary);
+                    }
+
+                    if (item.IsBufferRentFromPool && MemoryMarshal.TryGetArray(item.CompressedBuffer, out var segment))
+                    {
+                        ArrayPool<byte>.Shared.Return(segment.Array!, clearArray: false);
+                    }
+
+                    var item2 = new DecompressionOutputBuffer
+                    {
+                        Id = item.Id,
+                        DecompressedBuffer = destination,
+                        Count = written
+                    };
+
+                    await outputChannel.Writer.WriteAsync(item2, channelToken.Token);
+                }
+            }
+        });
+#else
+        var inputConsumerOutputProducerTasks = new Task[threadCount];
+        for (var i = 0; i < inputConsumerOutputProducerTasks.Length; i++)
+        {
+            inputConsumerOutputProducerTasks[i] = Task.Run(async () =>
             {
                 while (await inputChannel.Reader.WaitToReadAsync(channelToken.Token))
                 {
@@ -837,7 +875,8 @@ public static partial class LZ4
                             written = LZ4.Block.Decompress(item.CompressedBuffer.Span, destination, dictionary);
                         }
 
-                        if (item.IsBufferRentFromPool && MemoryMarshal.TryGetArray(item.CompressedBuffer, out var segment))
+                        if (item.IsBufferRentFromPool &&
+                            MemoryMarshal.TryGetArray(item.CompressedBuffer, out var segment))
                         {
                             ArrayPool<byte>.Shared.Return(segment.Array!, clearArray: false);
                         }
@@ -855,6 +894,9 @@ public static partial class LZ4
             });
         }
 
+        inputConsumerOutputProducers = Task.WhenAll(inputConsumerOutputProducerTasks);
+#endif
+    
         return inputConsumerOutputProducers;
     }
 


### PR DESCRIPTION
Replacing Task.WhenAll to Parallel.ForAsync removes tasks being allocated.
*When count of threads being used declines, the allocation reduction also decline and match to Task.WhenAll.
The PR has duplicated codes because of .NET Standard 2.1 support remains. I wasn't able to find better solution without causing regression.

main:
| Method                                     | Mean      | Error | Payload | Allocated |
|------------------------------------------- |----------:|------:|--------:|----------:|
| K4os_LZ4_Encode                            | 256.49 ms |    NA | 96.21MB |         - |
| K4os_LZ4_FrameEncode                       | 265.05 ms |    NA | 96.23MB |     572 B |
| NativeCompressions_LZ4_Compress            | 218.25 ms |    NA | 96.23MB |         - |
| NativeCompressions_LZ4_CompressMultiThread |  15.47 ms |    NA | 96.25MB |   16437 B |

| Method                                       | Mean     | Error | Payload  | Allocated |
|--------------------------------------------- |---------:|------:|---------:|----------:|
| K4os_LZ4_Decode                              | 40.90 ms |    NA | 202.13MB |         - |
| K4os_LZ4_FrameDecode                         | 67.76 ms |    NA | 202.13MB |   41462 B |
| NativeCompressions_LZ4_Decompress            | 34.47 ms |    NA | 202.13MB |      56 B |
| NativeCompressions_LZ4_DecompressMultiThread | 10.43 ms |    NA | 202.13MB |   14215 B |

pr:
| Method                                     | Mean      | Error | Payload | Allocated |
|------------------------------------------- |----------:|------:|--------:|----------:|
| K4os_LZ4_Encode                            | 296.34 ms |    NA | 96.21MB |         - |
| K4os_LZ4_FrameEncode                       | 266.53 ms |    NA | 96.23MB |     496 B |
| NativeCompressions_LZ4_Compress            | 225.48 ms |    NA | 96.23MB |         - |
| NativeCompressions_LZ4_CompressMultiThread |  15.92 ms |    NA | 96.25MB |    9605 B |

| Method                                       | Mean     | Error | Payload  | Allocated |
|--------------------------------------------- |---------:|------:|---------:|----------:|
| K4os_LZ4_Decode                              | 41.30 ms |    NA | 202.13MB |         - |
| K4os_LZ4_FrameDecode                         | 67.14 ms |    NA | 202.13MB |     496 B |
| NativeCompressions_LZ4_Decompress            | 34.46 ms |    NA | 202.13MB |      56 B |
| NativeCompressions_LZ4_DecompressMultiThread | 10.36 ms |    NA | 202.13MB |   10094 B |
