### PR TITLE
ci: Fixes OpenZL CI build failures

### DIFF
--- a/.github/workflows/build-native-openzl.yaml
+++ b/.github/workflows/build-native-openzl.yaml
@@ -204,6 +204,9 @@ jobs:
           echo "Updated openzl submodule to ${{ needs.check_new_release.outputs.latest_tag }}"
       # TODO: Currently, the build artifact extension is .so even on macOS. OpenZL may update the Makefile in the future to create .dylib files for macOS, which could cause CI errors. Please update the file extensions accordingly if this change occurs.
       - name: Build dynamic library
+        env:
+          CFLAGS: ${{ matrix.flags }}
+          LDFLAGS: ${{ matrix.flags }}
         run: |
           cd openzl
           make libopenzl.so BUILD_TYPE=OPT MOREFLAGS="${{ matrix.flags }} -flto" -j "$(sysctl -n hw.ncpu)"

--- a/.github/workflows/build-native-openzl.yaml
+++ b/.github/workflows/build-native-openzl.yaml
@@ -101,10 +101,16 @@ jobs:
         run: |
           docker run --rm -v "$PWD:/work" \
             mstorsjo/llvm-mingw:latest \
-            bash -c "cd /work/openzl && \
+            bash -c "
+              git config --global --add safe.directory /work/openzl && \
+              cd /work/openzl && \
+              export CC=aarch64-w64-mingw32-gcc && \
+              export WINDRES=aarch64-w64-mingw32-windres && \
+              export TARGET_OS=MINGW64 && \
+              export TARGET_SYSTEM=Windows_NT && \
               make libopenzl.so BUILD_TYPE=OPT OS=Windows_NT \
-              CC=aarch64-w64-mingw32-gcc \
-              MOREFLAGS='-flto'"
+                CC=aarch64-w64-mingw32-gcc \
+                MOREFLAGS='-flto'"
           file -L openzl/libopenzl.so
       - name: Prepare artifacts
         run: |

--- a/.github/workflows/build-native-openzl.yaml
+++ b/.github/workflows/build-native-openzl.yaml
@@ -10,6 +10,9 @@ name: Build-Native-OpenZL
 #     - Commit that updates the submodule
 #     - Commit that openzl dynamic lib artifacts placed in src/NativeCompressions.OpenZL.Runtime/runtimes/{platform_name}/native/{lib}
 on:
+  push:
+    branches:
+      - openzl
   workflow_dispatch:
   schedule:
     - cron: "0 3 * * *" # Every day at 3:00 AM (UTC)

--- a/.github/workflows/build-native-openzl.yaml
+++ b/.github/workflows/build-native-openzl.yaml
@@ -10,9 +10,6 @@ name: Build-Native-OpenZL
 #     - Commit that updates the submodule
 #     - Commit that openzl dynamic lib artifacts placed in src/NativeCompressions.OpenZL.Runtime/runtimes/{platform_name}/native/{lib}
 on:
-  push:
-    branches:
-      - openzl
   workflow_dispatch:
   schedule:
     - cron: "0 3 * * *" # Every day at 3:00 AM (UTC)

--- a/.github/workflows/build-native-openzl.yaml
+++ b/.github/workflows/build-native-openzl.yaml
@@ -114,6 +114,11 @@ jobs:
               make libopenzl.so BUILD_TYPE=OPT OS=Windows_NT \
                 CC=aarch64-w64-mingw32-gcc \
                 MOREFLAGS='-flto'"
+          # NOTE: Environment exports (CC, WINDRES, TARGET_OS, TARGET_SYSTEM) propagate to
+          # dependency sub-makes (lz4, zstd) whose MAKEOVERRIDES is cleared by OpenZL's Makefile.
+          # Command-line CC= is also needed for the parent make (highest priority in GNU Make).
+          # TARGET_OS=MINGW64 (not Windows_NT) is required because lz4's Makefile.inc produces
+          # 'liblz4.dll' for MINGW% but 'liblz4-1.dll' for Windows%, and OpenZL expects the former.
           file -L openzl/libopenzl.so
       - name: Prepare artifacts
         run: |
@@ -203,13 +208,20 @@ jobs:
           cd ..
           echo "Updated openzl submodule to ${{ needs.check_new_release.outputs.latest_tag }}"
       # TODO: Currently, the build artifact extension is .so even on macOS. OpenZL may update the Makefile in the future to create .dylib files for macOS, which could cause CI errors. Please update the file extensions accordingly if this change occurs.
+      # NOTE: Arch flags must reach dependency sub-makes (lz4, zstd) whose MAKEOVERRIDES is
+      # cleared by OpenZL's Makefile. CC with embedded arch is the most robust method because
+      # zstd uses SET_CACHE_DIRECTORY which re-invokes make and may not preserve env CFLAGS.
+      # CXXFLAGS is needed because OpenZL's addTargetAsmObject macro uses $(CC) $(CXXFLAGS)
+      # for .S files (not CFLAGS). MOREFLAGS only carries -flto for the parent make.
       - name: Build dynamic library
         env:
+          CC: "clang ${{ matrix.flags }}"
           CFLAGS: ${{ matrix.flags }}
+          CXXFLAGS: ${{ matrix.flags }}
           LDFLAGS: ${{ matrix.flags }}
         run: |
           cd openzl
-          make libopenzl.so BUILD_TYPE=OPT MOREFLAGS="${{ matrix.flags }} -flto" -j "$(sysctl -n hw.ncpu)"
+          make libopenzl.so BUILD_TYPE=OPT MOREFLAGS="-flto" -j "$(sysctl -n hw.ncpu)"
           ls -la
           lipo -info libopenzl.so
           file -L libopenzl.so


### PR DESCRIPTION
## Summary

Addresses CI build failures for the OpenZL dynamic library on Windows ARM64 and macOS x64.

*   **Windows ARM64:** Configures the `llvm-mingw` cross-compilation environment by exporting necessary `CC`, `WINDRES`, `TARGET_OS`, and `TARGET_SYSTEM` variables. This resolves compilation issues specific to the Windows ARM64 target within the Docker container. It also adds `git config --global --add safe.directory` to prevent potential repository access issues during the build.
*   **macOS x64:** Passes `CFLAGS` and `LDFLAGS` as environment variables to the `make` command, ensuring that all compilation flags are correctly applied during the build process on macOS.

These changes ensure the continuous integration pipeline successfully builds the OpenZL library across the specified architectures and operating systems.

## See related

OpenZL 0.2.0 upgraded PR was created. https://github.com/Cysharp/NativeCompressions/pull/64

> [!NOTE]
> Will rebase #64 with after this PR merge.

## Build

**Before**

https://github.com/Cysharp/NativeCompressions/actions/runs/26205423182

Windows arm64
```
make[1]: Entering directory '/work/openzl/deps/lz4/lib'
compiling dynamic library 1.10.0
lld: error: unknown argument: -soname=liblz4.so.1
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: Leaving directory '/work/openzl/deps/lz4/lib'
make[1]: *** [Makefile:134: liblz4.so.1.10.0] Error 1
make: *** [Makefile:442: deps/lz4/lib/liblz4.dll] Error 2
make: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/work/openzl/deps/zstd/lib'
Error: Process completed with exit code 2.
```

macos x64

```
compiling dynamic library 1.10.0
creating versioned links
LD cachedObjs/677918bff3c14b1df9f4328a1f73a4c3/libopenzl.so
ld: warning: ignoring file 'deps/lz4/lib/liblz4.dylib': found architecture 'arm64', required architecture 'x86_64'
Undefined symbols for architecture x86_64:
  "_LZ4_compressBound", referenced from:
      _EI_lz4 in lto.o
  "_LZ4_compress_HC", referenced from:
      _EI_lz4 in lto.o
  "_LZ4_compress_fast", referenced from:
      _EI_lz4 in lto.o
  "_LZ4_decompress_safe", referenced from:
      _DI_lz4 in lto.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [cachedObjs/677918bff3c14b1df9f4328a1f73a4c3/libopenzl.so] Error 1
```

**After**

https://github.com/Cysharp/NativeCompressions/actions/runs/26243194312